### PR TITLE
Remove `confsnap` domain

### DIFF
--- a/presentations/ngConf-2018/index.md
+++ b/presentations/ngConf-2018/index.md
@@ -1,6 +1,6 @@
 # Presentations:
 * [All Videos](https://nitayneeman.com/posts/all-talks-from-ng-conf-2018/)
-* [All Slides](http://confsnap.com/event/ng-conf-18)
+* All Slides (link unavailable, `confsnap` is no longer in operation)
 * [Reactive Testing Strategies with NgRx](https://brandonroberts.github.io/ngrx-ngconf-2018/ngrx-testing/assets/player/KeynoteDHTMLPlayer.html) (@brandontroberts & @MikeRyanDev)
 * [Docker slides](http://codewithdan.me/ng-containers)
 * [Nrwl slides for recommendations](https://drive.google.com/drive/folders/13OnVqbFvz-w-dDc2FQ9_Yv2eXmrhBl5X)

--- a/presentations/ngConf-2018/notes/NG-Conf-Day-1-41818.md
+++ b/presentations/ngConf-2018/notes/NG-Conf-Day-1-41818.md
@@ -286,7 +286,7 @@ Component harness - page object framework for components.  Shared between unit t
 # Notes
 ## Slides
 
-http://confsnap.com/#/event/ng-conf-18
+link unavailable, `confsnap` is no longer in operation
 https://github.com/DanWahlin/Angular-Docker-Microservices
 http://g.co/ng/seo-talk
 https://oasisdigital.com/

--- a/presentations/ngConf-2018/notes/NG-Conf-Day-2-41918.md
+++ b/presentations/ngConf-2018/notes/NG-Conf-Day-2-41918.md
@@ -173,7 +173,7 @@ Container gets data → Presentation patches values onto formGroup → Value Cha
   - App State → login info
   - UI State → current page
 
-http://confsnap.com/#/event/ng-conf-18/131
+(link unavailable, `confsnap` is no longer in operation)
 
 ----------
 # Reducing the Boilerplate with NgRx
@@ -434,5 +434,5 @@ https://store.docker.com/editions/community/docker-ce-desktop-mac
 @ngrx/entity
 ngrx dev tools - Schematics
 this.store.pipe(select(…));
-http://confsnap.com/#/event/ng-conf-18/131
+(unavailable, `confsnap` is no longer in operation)
 https://github.com/ngrx/platform/blob/master/example-app/app/books/reducers/books.spec.ts


### PR DESCRIPTION
It appears that `confsnap` is no longer in operation, and the domain is now used for NSFW content.